### PR TITLE
Add Property-level IsRequired method

### DIFF
--- a/property.go
+++ b/property.go
@@ -67,3 +67,17 @@ func (p *Property) String() string {
 
 	return string(b)
 }
+
+func (p *Property) IsRequired(name string) bool {
+	if p == nil {
+		return false
+	}
+
+	for _, req := range p.Required {
+		if req == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/property_test.go
+++ b/property_test.go
@@ -1,0 +1,47 @@
+package cfschema_test
+
+import (
+	"testing"
+
+	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
+)
+
+func TestPropertyIsRequired(t *testing.T) {
+	testCases := []struct {
+		TestDescription string
+		Property        *cfschema.Property
+		Name            string
+		Expected        bool
+	}{
+		{
+			TestDescription: "nil resource",
+			Property:        nil,
+			Name:            "test",
+			Expected:        false,
+		},
+		{
+			TestDescription: "not found",
+			Property:        &cfschema.Property{},
+			Name:            "test",
+			Expected:        false,
+		},
+		{
+			TestDescription: "found",
+			Property: &cfschema.Property{
+				Required: []string{"test"},
+			},
+			Name:     "test",
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.TestDescription, func(t *testing.T) {
+			if actual, expected := testCase.Property.IsRequired(testCase.Name), testCase.Expected; actual != expected {
+				t.Fatalf("expected (%t), got: %t", expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1.

```console
% go test -v .
=== RUN   TestMetaJsonSchemaValidateResourceDocument
=== RUN   TestMetaJsonSchemaValidateResourceDocument/valid
=== RUN   TestMetaJsonSchemaValidateResourceDocument/invalid
--- PASS: TestMetaJsonSchemaValidateResourceDocument (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourceDocument/valid (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourceDocument/invalid (0.00s)
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema/valid
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema/invalid
--- PASS: TestMetaJsonSchemaValidateResourceJsonSchema (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourceJsonSchema/valid (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourceJsonSchema/invalid (0.00s)
=== RUN   TestMetaJsonSchemaValidateResourcePath
=== RUN   TestMetaJsonSchemaValidateResourcePath/valid
=== RUN   TestMetaJsonSchemaValidateResourcePath/invalid
--- PASS: TestMetaJsonSchemaValidateResourcePath (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourcePath/valid (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourcePath/invalid (0.00s)
=== RUN   TestNewMetaJsonSchemaDocument
=== RUN   TestNewMetaJsonSchemaDocument/valid
=== RUN   TestNewMetaJsonSchemaDocument/invalid
--- PASS: TestNewMetaJsonSchemaDocument (0.00s)
    --- PASS: TestNewMetaJsonSchemaDocument/valid (0.00s)
    --- PASS: TestNewMetaJsonSchemaDocument/invalid (0.00s)
=== RUN   TestNewMetaJsonSchemaPath
=== RUN   TestNewMetaJsonSchemaPath/valid
=== RUN   TestNewMetaJsonSchemaPath/invalid
--- PASS: TestNewMetaJsonSchemaPath (0.00s)
    --- PASS: TestNewMetaJsonSchemaPath/valid (0.00s)
    --- PASS: TestNewMetaJsonSchemaPath/invalid (0.00s)
=== RUN   TestPropertyJsonPointerEqualsPath
=== RUN   TestPropertyJsonPointerEqualsPath/empty
=== RUN   TestPropertyJsonPointerEqualsPath/not_found
=== RUN   TestPropertyJsonPointerEqualsPath/first_level_match
=== RUN   TestPropertyJsonPointerEqualsPath/first_level_mismatch
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_match
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_front
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_back
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_front
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_back
--- PASS: TestPropertyJsonPointerEqualsPath (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/not_found (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/first_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/first_level_mismatch (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_back (0.00s)
=== RUN   TestPropertyJsonPointerEqualsStringPath
=== RUN   TestPropertyJsonPointerEqualsStringPath/empty
=== RUN   TestPropertyJsonPointerEqualsStringPath/not_found
=== RUN   TestPropertyJsonPointerEqualsStringPath/first_level_match
=== RUN   TestPropertyJsonPointerEqualsStringPath/first_level_mismatch
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_match
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_front
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_back
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_front
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_back
--- PASS: TestPropertyJsonPointerEqualsStringPath (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/not_found (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/first_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/first_level_mismatch (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_back (0.00s)
=== RUN   TestPropertyJsonPointerPath
=== RUN   TestPropertyJsonPointerPath/empty
=== RUN   TestPropertyJsonPointerPath/one_level
=== RUN   TestPropertyJsonPointerPath/multi_level
--- PASS: TestPropertyJsonPointerPath (0.00s)
    --- PASS: TestPropertyJsonPointerPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerPath/one_level (0.00s)
    --- PASS: TestPropertyJsonPointerPath/multi_level (0.00s)
=== RUN   TestPropertyIsRequired
=== RUN   TestPropertyIsRequired/nil_resource
=== RUN   TestPropertyIsRequired/not_found
=== RUN   TestPropertyIsRequired/found
--- PASS: TestPropertyIsRequired (0.00s)
    --- PASS: TestPropertyIsRequired/nil_resource (0.00s)
    --- PASS: TestPropertyIsRequired/not_found (0.00s)
    --- PASS: TestPropertyIsRequired/found (0.00s)
=== RUN   TestReferenceField
=== RUN   TestReferenceField/empty
=== RUN   TestReferenceField/root
=== RUN   TestReferenceField/definitions_prefix_only
=== RUN   TestReferenceField/properties_prefix_only
=== RUN   TestReferenceField/definition
=== RUN   TestReferenceField/property
--- PASS: TestReferenceField (0.00s)
    --- PASS: TestReferenceField/empty (0.00s)
    --- PASS: TestReferenceField/root (0.00s)
    --- PASS: TestReferenceField/definitions_prefix_only (0.00s)
    --- PASS: TestReferenceField/properties_prefix_only (0.00s)
    --- PASS: TestReferenceField/definition (0.00s)
    --- PASS: TestReferenceField/property (0.00s)
=== RUN   TestReferenceType
=== RUN   TestReferenceType/empty
=== RUN   TestReferenceType/root
=== RUN   TestReferenceType/definitions_prefix_only
=== RUN   TestReferenceType/properties_prefix_only
=== RUN   TestReferenceType/definition
=== RUN   TestReferenceType/property
--- PASS: TestReferenceType (0.00s)
    --- PASS: TestReferenceType/empty (0.00s)
    --- PASS: TestReferenceType/root (0.00s)
    --- PASS: TestReferenceType/definitions_prefix_only (0.00s)
    --- PASS: TestReferenceType/properties_prefix_only (0.00s)
    --- PASS: TestReferenceType/definition (0.00s)
    --- PASS: TestReferenceType/property (0.00s)
=== RUN   TestResourceExpand
=== RUN   TestResourceExpand/valid
--- PASS: TestResourceExpand (0.00s)
    --- PASS: TestResourceExpand/valid (0.00s)
=== RUN   TestResourceJsonSchemaResource
=== RUN   TestResourceJsonSchemaResource/valid
--- PASS: TestResourceJsonSchemaResource (0.00s)
    --- PASS: TestResourceJsonSchemaResource/valid (0.00s)
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument/valid
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument/invalid
--- PASS: TestResourceJsonSchemaValidateConfigurationDocument (0.01s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationDocument/valid (0.00s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationDocument/invalid (0.00s)
=== RUN   TestResourceJsonSchemaValidateConfigurationPath
=== RUN   TestResourceJsonSchemaValidateConfigurationPath/valid
=== RUN   TestResourceJsonSchemaValidateConfigurationPath/invalid
--- PASS: TestResourceJsonSchemaValidateConfigurationPath (0.01s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationPath/valid (0.00s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationPath/invalid (0.00s)
=== RUN   TestNewResourceJsonSchemaDocument
=== RUN   TestNewResourceJsonSchemaDocument/valid
=== RUN   TestNewResourceJsonSchemaDocument/invalid
--- PASS: TestNewResourceJsonSchemaDocument (0.00s)
    --- PASS: TestNewResourceJsonSchemaDocument/valid (0.00s)
    --- PASS: TestNewResourceJsonSchemaDocument/invalid (0.00s)
=== RUN   TestNewResourceJsonSchemaPath
=== RUN   TestNewResourceJsonSchemaPath/valid
=== RUN   TestNewResourceJsonSchemaPath/invalid
--- PASS: TestNewResourceJsonSchemaPath (0.00s)
    --- PASS: TestNewResourceJsonSchemaPath/valid (0.00s)
    --- PASS: TestNewResourceJsonSchemaPath/invalid (0.00s)
=== RUN   TestResourceIsRequired
=== RUN   TestResourceIsRequired/nil_resource
=== RUN   TestResourceIsRequired/not_found
=== RUN   TestResourceIsRequired/found
--- PASS: TestResourceIsRequired (0.00s)
    --- PASS: TestResourceIsRequired/nil_resource (0.00s)
    --- PASS: TestResourceIsRequired/not_found (0.00s)
    --- PASS: TestResourceIsRequired/found (0.00s)
=== RUN   TestResourceResolveProperty
=== RUN   TestResourceResolveProperty/nil_resource
=== RUN   TestResourceResolveProperty/nil_property
=== RUN   TestResourceResolveProperty/passthrough
=== RUN   TestResourceResolveProperty/missing_definition
=== RUN   TestResourceResolveProperty/missing_property
=== RUN   TestResourceResolveProperty/definition_ref
=== RUN   TestResourceResolveProperty/definition_type
=== RUN   TestResourceResolveProperty/property_ref
--- PASS: TestResourceResolveProperty (0.00s)
    --- PASS: TestResourceResolveProperty/nil_resource (0.00s)
    --- PASS: TestResourceResolveProperty/nil_property (0.00s)
    --- PASS: TestResourceResolveProperty/passthrough (0.00s)
    --- PASS: TestResourceResolveProperty/missing_definition (0.00s)
    --- PASS: TestResourceResolveProperty/missing_property (0.00s)
    --- PASS: TestResourceResolveProperty/definition_ref (0.00s)
    --- PASS: TestResourceResolveProperty/definition_type (0.00s)
    --- PASS: TestResourceResolveProperty/property_ref (0.00s)
PASS
ok  	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go	4.078s
```