### PR TITLE
Add `Sanitize`.

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,20 @@
+package cfschema
+
+import (
+	"regexp"
+)
+
+var (
+	sanitizePattern           = regexp.MustCompile(`(?m)^(\s+"pattern"\s*:\s*)".*"`)
+	sanitizePatternProperties = regexp.MustCompile(`(?m)^(\s+"patternProperties"\s*:\s*{\s*)".*?"`)
+)
+
+// Sanitize returns a sanitized copy of the specified JSON Schema document.
+// The santized copy rewrites all pattern and patternProperty regexes to the empty string,
+// working around any problems with JSON Schema regex validation.
+func Sanitize(document string) string {
+	document = sanitizePattern.ReplaceAllString(document, `$1""`)
+	document = sanitizePatternProperties.ReplaceAllString(document, `$1""`)
+
+	return document
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,135 @@
+package cfschema_test
+
+import (
+	"testing"
+
+	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
+)
+
+func TestSanitize(t *testing.T) {
+	testCases := []struct {
+		TestDescription   string
+		InputDocument     string
+		SanitizedDocument string
+	}{
+		{
+			TestDescription: "Nothing to sanitize",
+			InputDocument: `
+{
+  "LogGroupName": {
+    "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512
+  },
+}
+			`,
+			SanitizedDocument: `
+{
+  "LogGroupName": {
+    "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512
+  },
+}
+			`,
+		},
+		{
+			TestDescription: "Sanitize pattern",
+			InputDocument: `
+{
+  "LogGroupName": {
+    "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": "^[.\\-_/#A-Za-z0-9]{1,512}\\Z"
+  },
+  "KmsKeyId": {
+    "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.",
+    "type": "string",
+    "pattern": "^arn:[a-z0-9-]+:kms:[a-z0-9-]+:\\d{12}:(key|alias)/.+\\Z",
+    "maxLength": 256
+  }
+}
+			`,
+			SanitizedDocument: `
+{
+  "LogGroupName": {
+    "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": ""
+  },
+  "KmsKeyId": {
+    "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.",
+    "type": "string",
+    "pattern": "",
+    "maxLength": 256
+  }
+}
+			`,
+		},
+		{
+			TestDescription: "Sanitize patternProperties",
+			InputDocument: `
+{
+  "BackupPlanTags": {
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+      "^.{1,128}$": {
+        "type": "string"
+      }
+    }
+  },
+  "RecoveryPointTags": {
+    "type": "object",
+    "patternProperties": {
+      "^.{1,128}$": {
+        "type": "string"
+      },
+    "additionalProperties": false
+    }
+  }
+}
+			`,
+			SanitizedDocument: `
+{
+  "BackupPlanTags": {
+    "type": "object",
+    "additionalProperties": false,
+    "patternProperties": {
+      "": {
+        "type": "string"
+      }
+    }
+  },
+  "RecoveryPointTags": {
+    "type": "object",
+    "patternProperties": {
+      "": {
+        "type": "string"
+      },
+    "additionalProperties": false
+    }
+  }
+}
+			`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.TestDescription, func(t *testing.T) {
+			got := cfschema.Sanitize(testCase.InputDocument)
+
+			if got != testCase.SanitizedDocument {
+				t.Errorf("expected: %s, got: %s", testCase.SanitizedDocument, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #22.

```console
% go test -v . '-run=TestSanitize'
=== RUN   TestSanitize
=== RUN   TestSanitize/Nothing_to_sanitize
=== RUN   TestSanitize/Sanitize_pattern
=== RUN   TestSanitize/Sanitize_patternProperties
--- PASS: TestSanitize (0.00s)
    --- PASS: TestSanitize/Nothing_to_sanitize (0.00s)
    --- PASS: TestSanitize/Sanitize_pattern (0.00s)
    --- PASS: TestSanitize/Sanitize_patternProperties (0.00s)
PASS
ok  	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go	0.661s
```