### PR TITLE
Add `propertyTransform' helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-.idea
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.17.0 (Unreleased)
+
+Add helper to `propertyTransform` to get values based on path.
+
 ## v0.16.0 (February 20, 2022)
 
 `Santize` now only removes property `pattern` regexes not supported by Go.

--- a/property_transform.go
+++ b/property_transform.go
@@ -1,0 +1,37 @@
+package cfschema
+
+import (
+	"strings"
+)
+
+// PropertyTransform represents property transform values.
+type PropertyTransform map[string]string
+
+// Value returns the value for a specified property path.
+func (p PropertyTransform) Value(path []string) (string, bool) {
+	pa := buildPath(path)
+
+	if value, ok := pathClean(p)[pa]; ok {
+		return value, true
+	}
+
+	return "", false
+}
+
+func buildPath(path []string) string {
+	if len(path) == 1 {
+		return path[0]
+	}
+
+	return strings.Join(path, "/")
+}
+
+func pathClean(m map[string]string) map[string]string {
+	vals := make(map[string]string)
+
+	for k, v := range m {
+		vals[strings.TrimPrefix(string(k), PropertiesJsonPointerPrefix+JsonPointerReferenceTokenSeparator)] = v
+	}
+
+	return vals
+}

--- a/property_transform_test.go
+++ b/property_transform_test.go
@@ -1,0 +1,49 @@
+package cfschema_test
+
+import (
+	"testing"
+
+	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
+)
+
+func TestPropertyTransformValue(t *testing.T) {
+	testCases := []struct {
+		Name              string
+		PropertyTransform cfschema.PropertyTransform
+		Path              []string
+		Expected          string
+	}{
+		{
+			Name: "found",
+			PropertyTransform: cfschema.PropertyTransform{
+				"/properties/TestPath": "$lowercase(TestPath)",
+			},
+			Path:     []string{"TestPath"},
+			Expected: "$lowercase(TestPath)",
+		},
+		{
+			Name: "not found",
+			PropertyTransform: cfschema.PropertyTransform{
+				"/properties/TestPath": "$lowercase(TestPath)",
+			},
+			Path:     []string{"TestPath", "SubProperty"},
+			Expected: "",
+		},
+		{
+			Name: "found nested property",
+			PropertyTransform: cfschema.PropertyTransform{
+				"/properties/TestPath/SubProperty": "$lowercase(TestPath.SubProperty)",
+			},
+			Path:     []string{"TestPath", "SubProperty"},
+			Expected: "$lowercase(TestPath.SubProperty)",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			if actual, _ := testCase.PropertyTransform.Value(testCase.Path); actual != testCase.Expected {
+				t.Fatalf("expected (%s), got: %s", testCase.Expected, actual)
+			}
+		})
+	}
+}

--- a/resource.go
+++ b/resource.go
@@ -18,7 +18,7 @@ type Resource struct {
 	OneOf                           []*PropertySubschema   `json:"oneOf,omitempty"`
 	PrimaryIdentifier               PropertyJsonPointers   `json:"primaryIdentifier,omitempty"`
 	Properties                      map[string]*Property   `json:"properties,omitempty"`
-	PropertyTransform               map[string]string      `json:"propertyTransform,omitempty"`
+	PropertyTransform               PropertyTransform      `json:"propertyTransform,omitempty"`
 	ReadOnlyProperties              PropertyJsonPointers   `json:"readOnlyProperties,omitempty"`
 	ReplacementStrategy             *string                `json:"replacementStrategy,omitempty"`
 	Required                        []string               `json:"required,omitempty"`


### PR DESCRIPTION
Relates to hashicorp/terraform-provider-awscc#202

```console
$ go test -v property_transform_test.go

=== RUN   TestPropertyTransformValue
=== RUN   TestPropertyTransformValue/found
=== RUN   TestPropertyTransformValue/not_found
=== RUN   TestPropertyTransformValue/found_nested_property
--- PASS: TestPropertyTransformValue (0.00s)
    --- PASS: TestPropertyTransformValue/found (0.00s)
    --- PASS: TestPropertyTransformValue/not_found (0.00s)
    --- PASS: TestPropertyTransformValue/found_nested_property (0.00s)
PASS
ok  	command-line-arguments	0.148s
```