### PR TITLE
Change `Property.Maximum` and `Property.Minimum` to `json.Number`

### DIFF
--- a/property.go
+++ b/property.go
@@ -47,10 +47,10 @@ type Property struct {
 	Format               *string              `json:"format,omitempty"`
 	InsertionOrder       *bool                `json:"insertionOrder,omitempty"`
 	Items                *Property            `json:"items,omitempty"`
-	Maximum              *int                 `json:"maximum,omitempty"`
+	Maximum              *int64               `json:"maximum,omitempty"`
 	MaxItems             *int                 `json:"maxItems,omitempty"`
 	MaxLength            *int                 `json:"maxLength,omitempty"`
-	Minimum              *int                 `json:"minimum,omitempty"`
+	Minimum              *int64               `json:"minimum,omitempty"`
 	MinItems             *int                 `json:"minItems,omitempty"`
 	MinLength            *int                 `json:"minLength,omitempty"`
 	OneOf                []*PropertySubschema `json:"oneOf,omitempty"`

--- a/property.go
+++ b/property.go
@@ -47,10 +47,10 @@ type Property struct {
 	Format               *string              `json:"format,omitempty"`
 	InsertionOrder       *bool                `json:"insertionOrder,omitempty"`
 	Items                *Property            `json:"items,omitempty"`
-	Maximum              *int64               `json:"maximum,omitempty"`
+	Maximum              *json.Number         `json:"maximum,omitempty"`
 	MaxItems             *int                 `json:"maxItems,omitempty"`
 	MaxLength            *int                 `json:"maxLength,omitempty"`
-	Minimum              *int64               `json:"minimum,omitempty"`
+	Minimum              *json.Number         `json:"minimum,omitempty"`
 	MinItems             *int                 `json:"minItems,omitempty"`
 	MinLength            *int                 `json:"minLength,omitempty"`
 	OneOf                []*PropertySubschema `json:"oneOf,omitempty"`


### PR DESCRIPTION
Closes #41.

```console
% go test -v .
=== RUN   TestMetaJsonSchemaValidateResourceDocument
=== RUN   TestMetaJsonSchemaValidateResourceDocument/valid
=== RUN   TestMetaJsonSchemaValidateResourceDocument/invalid
--- PASS: TestMetaJsonSchemaValidateResourceDocument (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourceDocument/valid (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourceDocument/invalid (0.00s)
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema/valid
=== RUN   TestMetaJsonSchemaValidateResourceJsonSchema/invalid
--- PASS: TestMetaJsonSchemaValidateResourceJsonSchema (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourceJsonSchema/valid (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourceJsonSchema/invalid (0.00s)
=== RUN   TestMetaJsonSchemaValidateResourcePath
=== RUN   TestMetaJsonSchemaValidateResourcePath/valid
=== RUN   TestMetaJsonSchemaValidateResourcePath/invalid
--- PASS: TestMetaJsonSchemaValidateResourcePath (0.01s)
    --- PASS: TestMetaJsonSchemaValidateResourcePath/valid (0.00s)
    --- PASS: TestMetaJsonSchemaValidateResourcePath/invalid (0.00s)
=== RUN   TestNewMetaJsonSchemaDocument
=== RUN   TestNewMetaJsonSchemaDocument/valid
=== RUN   TestNewMetaJsonSchemaDocument/invalid
--- PASS: TestNewMetaJsonSchemaDocument (0.00s)
    --- PASS: TestNewMetaJsonSchemaDocument/valid (0.00s)
    --- PASS: TestNewMetaJsonSchemaDocument/invalid (0.00s)
=== RUN   TestNewMetaJsonSchemaPath
=== RUN   TestNewMetaJsonSchemaPath/valid
=== RUN   TestNewMetaJsonSchemaPath/invalid
--- PASS: TestNewMetaJsonSchemaPath (0.00s)
    --- PASS: TestNewMetaJsonSchemaPath/valid (0.00s)
    --- PASS: TestNewMetaJsonSchemaPath/invalid (0.00s)
=== RUN   TestPropertyJsonPointerEqualsPath
=== RUN   TestPropertyJsonPointerEqualsPath/empty
=== RUN   TestPropertyJsonPointerEqualsPath/not_found
=== RUN   TestPropertyJsonPointerEqualsPath/first_level_match
=== RUN   TestPropertyJsonPointerEqualsPath/first_level_mismatch
=== RUN   TestPropertyJsonPointerEqualsPath/first_level_mismatch_with_prefix
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_match
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_front
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_back
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_front
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_back
=== RUN   TestPropertyJsonPointerEqualsPath/multi_level_mismatch_with_prefix
--- PASS: TestPropertyJsonPointerEqualsPath (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/not_found (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/first_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/first_level_mismatch (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/first_level_mismatch_with_prefix (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_only_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_wrong_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsPath/multi_level_mismatch_with_prefix (0.00s)
=== RUN   TestPropertyJsonPointerEqualsStringPath
=== RUN   TestPropertyJsonPointerEqualsStringPath/empty
=== RUN   TestPropertyJsonPointerEqualsStringPath/not_found
=== RUN   TestPropertyJsonPointerEqualsStringPath/first_level_match
=== RUN   TestPropertyJsonPointerEqualsStringPath/first_level_mismatch
=== RUN   TestPropertyJsonPointerEqualsStringPath/first_level_mismatch_with_prefix
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_match
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_front
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_back
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_front
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_back
=== RUN   TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_with_prefix
--- PASS: TestPropertyJsonPointerEqualsStringPath (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/not_found (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/first_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/first_level_mismatch (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/first_level_mismatch_with_prefix (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_match (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_only_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_front (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_wrong_back (0.00s)
    --- PASS: TestPropertyJsonPointerEqualsStringPath/multi_level_mismatch_with_prefix (0.00s)
=== RUN   TestPropertyJsonPointerPath
=== RUN   TestPropertyJsonPointerPath/empty
=== RUN   TestPropertyJsonPointerPath/one_level
=== RUN   TestPropertyJsonPointerPath/multi_level
--- PASS: TestPropertyJsonPointerPath (0.00s)
    --- PASS: TestPropertyJsonPointerPath/empty (0.00s)
    --- PASS: TestPropertyJsonPointerPath/one_level (0.00s)
    --- PASS: TestPropertyJsonPointerPath/multi_level (0.00s)
=== RUN   TestPropertySubschema_Resource
=== RUN   TestPropertySubschema_Resource/resource_anyOf
=== RUN   TestPropertySubschema_Resource/resource_allOf
=== RUN   TestPropertySubschema_Resource/resource_no_subschema
--- PASS: TestPropertySubschema_Resource (0.02s)
    --- PASS: TestPropertySubschema_Resource/resource_anyOf (0.00s)
    --- PASS: TestPropertySubschema_Resource/resource_allOf (0.01s)
    --- PASS: TestPropertySubschema_Resource/resource_no_subschema (0.00s)
=== RUN   TestPropertySubschema_Property
=== RUN   TestPropertySubschema_Property/property_anyOf
=== RUN   TestPropertySubschema_Property/property_oneOf
--- PASS: TestPropertySubschema_Property (0.01s)
    --- PASS: TestPropertySubschema_Property/property_anyOf (0.01s)
    --- PASS: TestPropertySubschema_Property/property_oneOf (0.00s)
=== RUN   TestPropertyIsRequired
=== RUN   TestPropertyIsRequired/nil_resource
=== RUN   TestPropertyIsRequired/not_found
=== RUN   TestPropertyIsRequired/found
--- PASS: TestPropertyIsRequired (0.00s)
    --- PASS: TestPropertyIsRequired/nil_resource (0.00s)
    --- PASS: TestPropertyIsRequired/not_found (0.00s)
    --- PASS: TestPropertyIsRequired/found (0.00s)
=== RUN   TestPropertyTransformValue
=== RUN   TestPropertyTransformValue/found
=== RUN   TestPropertyTransformValue/not_found
=== RUN   TestPropertyTransformValue/found_nested_property
--- PASS: TestPropertyTransformValue (0.00s)
    --- PASS: TestPropertyTransformValue/found (0.00s)
    --- PASS: TestPropertyTransformValue/not_found (0.00s)
    --- PASS: TestPropertyTransformValue/found_nested_property (0.00s)
=== RUN   TestReferenceField
=== RUN   TestReferenceField/empty
=== RUN   TestReferenceField/root
=== RUN   TestReferenceField/definitions_prefix_only
=== RUN   TestReferenceField/properties_prefix_only
=== RUN   TestReferenceField/definition
=== RUN   TestReferenceField/property
=== RUN   TestReferenceField/definition_with_prefix
=== RUN   TestReferenceField/property_with_prefix
--- PASS: TestReferenceField (0.00s)
    --- PASS: TestReferenceField/empty (0.00s)
    --- PASS: TestReferenceField/root (0.00s)
    --- PASS: TestReferenceField/definitions_prefix_only (0.00s)
    --- PASS: TestReferenceField/properties_prefix_only (0.00s)
    --- PASS: TestReferenceField/definition (0.00s)
    --- PASS: TestReferenceField/property (0.00s)
    --- PASS: TestReferenceField/definition_with_prefix (0.00s)
    --- PASS: TestReferenceField/property_with_prefix (0.00s)
=== RUN   TestReferenceType
=== RUN   TestReferenceType/empty
=== RUN   TestReferenceType/root
=== RUN   TestReferenceType/definitions_prefix_only
=== RUN   TestReferenceType/properties_prefix_only
=== RUN   TestReferenceType/definition
=== RUN   TestReferenceType/property
--- PASS: TestReferenceType (0.00s)
    --- PASS: TestReferenceType/empty (0.00s)
    --- PASS: TestReferenceType/root (0.00s)
    --- PASS: TestReferenceType/definitions_prefix_only (0.00s)
    --- PASS: TestReferenceType/properties_prefix_only (0.00s)
    --- PASS: TestReferenceType/definition (0.00s)
    --- PASS: TestReferenceType/property (0.00s)
=== RUN   TestResourceExpand
=== RUN   TestResourceExpand/valid
--- PASS: TestResourceExpand (0.00s)
    --- PASS: TestResourceExpand/valid (0.00s)
=== RUN   TestResourceExpand_NestedDefinition
=== RUN   TestResourceExpand_NestedDefinition/valid
=== RUN   TestResourceExpand_NestedDefinition/valid_in_array
=== RUN   TestResourceExpand_NestedDefinition/no_type_specified
--- PASS: TestResourceExpand_NestedDefinition (0.02s)
    --- PASS: TestResourceExpand_NestedDefinition/valid (0.00s)
    --- PASS: TestResourceExpand_NestedDefinition/valid_in_array (0.01s)
    --- PASS: TestResourceExpand_NestedDefinition/no_type_specified (0.01s)
=== RUN   TestResourceExpand_PatternProperties
=== RUN   TestResourceExpand_PatternProperties/valid
--- PASS: TestResourceExpand_PatternProperties (0.01s)
    --- PASS: TestResourceExpand_PatternProperties/valid (0.01s)
=== RUN   TestResourceExpand_SecondLevelNestedDefinition
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/valid_1_level_simple
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/valid_1_level_object
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/valid_2_level_simple
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_object,_single_entry_with_ref
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_empty,_single_entry_with_refs
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_object,_multiple_entries_with_refs
=== RUN   TestResourceExpand_SecondLevelNestedDefinition/valid_2_level_array_of_objects
--- PASS: TestResourceExpand_SecondLevelNestedDefinition (0.03s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/valid_1_level_simple (0.01s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/valid_1_level_object (0.00s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/valid_2_level_simple (0.00s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_object,_single_entry_with_ref (0.00s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_empty,_single_entry_with_refs (0.00s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/unwrap_oneOf_type_object,_multiple_entries_with_refs (0.01s)
    --- PASS: TestResourceExpand_SecondLevelNestedDefinition/valid_2_level_array_of_objects (0.00s)
=== RUN   TestResourceJsonSchemaResource
=== RUN   TestResourceJsonSchemaResource/valid
--- PASS: TestResourceJsonSchemaResource (0.00s)
    --- PASS: TestResourceJsonSchemaResource/valid (0.00s)
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument/valid
=== RUN   TestResourceJsonSchemaValidateConfigurationDocument/invalid
--- PASS: TestResourceJsonSchemaValidateConfigurationDocument (0.01s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationDocument/valid (0.00s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationDocument/invalid (0.00s)
=== RUN   TestResourceJsonSchemaValidateConfigurationPath
=== RUN   TestResourceJsonSchemaValidateConfigurationPath/valid
=== RUN   TestResourceJsonSchemaValidateConfigurationPath/invalid
--- PASS: TestResourceJsonSchemaValidateConfigurationPath (0.01s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationPath/valid (0.00s)
    --- PASS: TestResourceJsonSchemaValidateConfigurationPath/invalid (0.00s)
=== RUN   TestNewResourceJsonSchemaDocument
=== RUN   TestNewResourceJsonSchemaDocument/valid
=== RUN   TestNewResourceJsonSchemaDocument/invalid
--- PASS: TestNewResourceJsonSchemaDocument (0.00s)
    --- PASS: TestNewResourceJsonSchemaDocument/valid (0.00s)
    --- PASS: TestNewResourceJsonSchemaDocument/invalid (0.00s)
=== RUN   TestNewResourceJsonSchemaPath
=== RUN   TestNewResourceJsonSchemaPath/valid
=== RUN   TestNewResourceJsonSchemaPath/invalid
--- PASS: TestNewResourceJsonSchemaPath (0.00s)
    --- PASS: TestNewResourceJsonSchemaPath/valid (0.00s)
    --- PASS: TestNewResourceJsonSchemaPath/invalid (0.00s)
=== RUN   TestResourceIsRequired
=== RUN   TestResourceIsRequired/nil_resource
=== RUN   TestResourceIsRequired/not_found
=== RUN   TestResourceIsRequired/found
--- PASS: TestResourceIsRequired (0.00s)
    --- PASS: TestResourceIsRequired/nil_resource (0.00s)
    --- PASS: TestResourceIsRequired/not_found (0.00s)
    --- PASS: TestResourceIsRequired/found (0.00s)
=== RUN   TestResourceResolveProperty
=== RUN   TestResourceResolveProperty/nil_property
=== RUN   TestResourceResolveProperty/passthrough
=== RUN   TestResourceResolveProperty/missing_definition
=== RUN   TestResourceResolveProperty/missing_property
=== RUN   TestResourceResolveProperty/definition_ref
=== RUN   TestResourceResolveProperty/definition_type
=== RUN   TestResourceResolveProperty/property_ref
--- PASS: TestResourceResolveProperty (0.00s)
    --- PASS: TestResourceResolveProperty/nil_property (0.00s)
    --- PASS: TestResourceResolveProperty/passthrough (0.00s)
    --- PASS: TestResourceResolveProperty/missing_definition (0.00s)
    --- PASS: TestResourceResolveProperty/missing_property (0.00s)
    --- PASS: TestResourceResolveProperty/definition_ref (0.00s)
    --- PASS: TestResourceResolveProperty/definition_type (0.00s)
    --- PASS: TestResourceResolveProperty/property_ref (0.00s)
=== RUN   TestSanitize
=== RUN   TestSanitize/Nothing_to_sanitize
=== RUN   TestSanitize/Sanitize_pattern
=== RUN   TestSanitize/Sanitize_patternProperties
--- PASS: TestSanitize (0.00s)
    --- PASS: TestSanitize/Nothing_to_sanitize (0.00s)
    --- PASS: TestSanitize/Sanitize_pattern (0.00s)
    --- PASS: TestSanitize/Sanitize_patternProperties (0.00s)
PASS
ok  	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go	0.535s
```