### PR TITLE
update sanitize function so that it works when schema is an unindented json string

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -2,6 +2,7 @@ package cfschema
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -14,9 +15,14 @@ var (
 
 // Sanitize returns a sanitized copy of the specified JSON Schema document.
 // The sanitized copy works around any problems with JSON Schema regex validation by
-//  - Rewriting all patternProperty regexes to the empty string (the regex is never used anyway)
-//  - Rewriting all unsupported (valid for ECMA-262 but not for Go) pattern regexes to the empty string
+//   - Rewriting all patternProperty regexes to the empty string (the regex is never used anyway)
+//   - Rewriting all unsupported (valid for ECMA-262 but not for Go) pattern regexes to the empty string
 func Sanitize(document string) (string, error) {
+	var formattedJSON bytes.Buffer
+	if err := json.Indent(&formattedJSON, []byte(document), "", "  "); err != nil {
+		return "", err
+	}
+	document = string(formattedJSON.Bytes())
 	document = sanitizePatternProperties.ReplaceAllString(document, `$1""`)
 
 	var sb strings.Builder

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -22,7 +22,7 @@ func TestSanitize(t *testing.T) {
     "type": "string",
     "minLength": 1,
     "maxLength": 512
-  },
+  }
 }
 			`,
 			SanitizedDocument: `
@@ -32,7 +32,7 @@ func TestSanitize(t *testing.T) {
     "type": "string",
     "minLength": 1,
     "maxLength": 512
-  },
+  }
 }
 			`,
 		},
@@ -92,15 +92,15 @@ func TestSanitize(t *testing.T) {
   "KmsKeyId": {
     "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.",
     "type": "string",
-    "pattern":"",
+    "pattern": "",
     "maxLength": 256
   },
-  "Key" : {
-    "type" : "string",
-    "pattern" : "",
-    "description" : "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.",
-    "minLength" : 1,
-    "maxLength" : 128
+  "Key": {
+    "type": "string",
+    "pattern": "",
+    "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.",
+    "minLength": 1,
+    "maxLength": 128
   },
   "VirtualMfaDeviceName": {
     "minLength": 1,
@@ -164,8 +164,54 @@ func TestSanitize(t *testing.T) {
       "": {
         "type": "string"
       },
-    "additionalProperties": false
+      "additionalProperties": false
     }
+  }
+}
+			`,
+		},
+		{
+			TestDescription: "Sanitize unindented JSON",
+			InputDocument:   `{"LogGroupName":{"description":"The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.","type":"string","minLength":1,"maxLength":512,"pattern":"^[.\\-_/#A-Za-z0-9]{1,512}\\Z"},"KmsKeyId":{"description":"The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.","type":"string","pattern":"^arn:[a-z0-9-]+:kms:[a-z0-9-]+:\\d{12}:(key|alias)/.+\\Z","maxLength":256},"Key":{"type":"string","pattern":"^(?!aws:)[a-zA-Z+-=._:/]+$","description":"The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.","minLength":1,"maxLength":128},"VirtualMfaDeviceName":{"minLength":1,"maxLength":226,"pattern":"[\\w+=,.@-]+","type":"string"},"Path":{"minLength":1,"maxLength":512,"pattern":"(\\u002F)|(\\u002F[\\u0021-\\u007F]+\\u002F)","type":"string"},"SerialNumber":{"minLength":9,"maxLength":256,"pattern":"[\\w+=/:,.@-]+","type":"string"}}`,
+			SanitizedDocument: `
+{
+  "LogGroupName": {
+    "description": "The name of the log group. If you don't specify a name, AWS CloudFormation generates a unique ID for the log group.",
+    "type": "string",
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": ""
+  },
+  "KmsKeyId": {
+    "description": "The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.",
+    "type": "string",
+    "pattern": "",
+    "maxLength": 256
+  },
+  "Key": {
+    "type": "string",
+    "pattern": "",
+    "description": "The key name of the tag. You can specify a value that is 1 to 128 Unicode characters in length and cannot be prefixed with aws:. You can use any of the following characters: the set of Unicode letters, digits, whitespace, _, ., /, =, +, and -.",
+    "minLength": 1,
+    "maxLength": 128
+  },
+  "VirtualMfaDeviceName": {
+    "minLength": 1,
+    "maxLength": 226,
+    "pattern": "[\\w+=,.@-]+",
+    "type": "string"
+  },
+  "Path": {
+    "minLength": 1,
+    "maxLength": 512,
+    "pattern": "",
+    "type": "string"
+  },
+  "SerialNumber": {
+    "minLength": 9,
+    "maxLength": 256,
+    "pattern": "[\\w+=/:,.@-]+",
+    "type": "string"
   }
 }
 			`,


### PR DESCRIPTION
Currently Terraform breaks for AWS CloudControl resources with error mentioned in this issue: https://github.com/hashicorp/terraform-provider-aws/issues/26351

The root cause being CloudFormation describe-type returns the schema as an unindented JSON string, something like this: `{"handlers":{"read":{"permissions":["lambda:GetFunction","lambda:GetFunctionCodeSigningConfig"]},"create":{"permissions":["lambda:CreateFunction",...<too long, redacted>...`, and the `Sanitize` function can only replace `patterns` that appear on its own line.

This PR updates the `Sanitize` function to work with the above format.