### PR TITLE
Add support for `arrayType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.20.0 (Unreleased)
+
+Support [`arrayType`](https://github.com/aws-cloudformation/cloudformation-resource-schema#arraytype).
+
 ## v0.19.0 (November 21, 2022)
 
 The `Sanitize` function formats the JSON document using [`json.Indent`](https://pkg.go.dev/encoding/json#Indent) before sanitizing.

--- a/property.go
+++ b/property.go
@@ -5,6 +5,11 @@ import (
 )
 
 const (
+	PropertyArrayTypeAttributeList = "AttributeList"
+	PropertyArrayTypeStandard      = "Standard"
+)
+
+const (
 	PropertyFormatDate                = "date"
 	PropertyFormatDateTime            = "date-time"
 	PropertyFormatEmail               = "email"
@@ -39,6 +44,7 @@ type Property struct {
 	AdditionalProperties *bool                `json:"additionalProperties,omitempty"`
 	AllOf                []*PropertySubschema `json:"allOf,omitempty"`
 	AnyOf                []*PropertySubschema `json:"anyOf,omitempty"`
+	ArrayType            *string              `json:"arrayType,omitempty"`
 	Comment              *string              `json:"$comment,omitempty"`
 	Default              interface{}          `json:"default,omitempty"`
 	Description          *string              `json:"description,omitempty"`


### PR DESCRIPTION
Closes https://github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go/issues/45.