### PR TITLE
Add support for `relationshipRef` for properties

### DIFF
--- a/handler_schema_test.go
+++ b/handler_schema_test.go
@@ -4,10 +4,7 @@
 package cfschema_test
 
 import (
-	"path/filepath"
 	"testing"
-
-	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
 )
 
 func TestHandlerSchema(t *testing.T) {
@@ -35,29 +32,7 @@ func TestHandlerSchema(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
 			got := 0
 

--- a/property.go
+++ b/property.go
@@ -44,32 +44,33 @@ const (
 
 // Property represents the CloudFormation Resource Schema customization for Definitions and Properties.
 type Property struct {
-	AdditionalProperties *bool                `json:"additionalProperties,omitempty"`
-	AllOf                []*PropertySubschema `json:"allOf,omitempty"`
-	AnyOf                []*PropertySubschema `json:"anyOf,omitempty"`
-	ArrayType            *string              `json:"arrayType,omitempty"`
-	Comment              *string              `json:"$comment,omitempty"`
-	Default              interface{}          `json:"default,omitempty"`
-	Description          *string              `json:"description,omitempty"`
-	Enum                 []interface{}        `json:"enum,omitempty"`
-	Examples             []interface{}        `json:"examples,omitempty"`
-	Format               *string              `json:"format,omitempty"`
-	InsertionOrder       *bool                `json:"insertionOrder,omitempty"`
-	Items                *Property            `json:"items,omitempty"`
-	Maximum              *json.Number         `json:"maximum,omitempty"`
-	MaxItems             *int                 `json:"maxItems,omitempty"`
-	MaxLength            *int                 `json:"maxLength,omitempty"`
-	Minimum              *json.Number         `json:"minimum,omitempty"`
-	MinItems             *int                 `json:"minItems,omitempty"`
-	MinLength            *int                 `json:"minLength,omitempty"`
-	OneOf                []*PropertySubschema `json:"oneOf,omitempty"`
-	Pattern              *string              `json:"pattern,omitempty"`
-	PatternProperties    map[string]*Property `json:"patternProperties,omitempty"`
-	Properties           map[string]*Property `json:"properties,omitempty"`
-	Ref                  *Reference           `json:"$ref,omitempty"`
-	Required             []string             `json:"required,omitempty"`
-	Type                 *Type                `json:"type,omitempty"`
-	UniqueItems          *bool                `json:"uniqueItems,omitempty"`
+	AdditionalProperties *bool                    `json:"additionalProperties,omitempty"`
+	AllOf                []*PropertySubschema     `json:"allOf,omitempty"`
+	AnyOf                []*PropertySubschema     `json:"anyOf,omitempty"`
+	ArrayType            *string                  `json:"arrayType,omitempty"`
+	Comment              *string                  `json:"$comment,omitempty"`
+	Default              interface{}              `json:"default,omitempty"`
+	Description          *string                  `json:"description,omitempty"`
+	Enum                 []interface{}            `json:"enum,omitempty"`
+	Examples             []interface{}            `json:"examples,omitempty"`
+	Format               *string                  `json:"format,omitempty"`
+	InsertionOrder       *bool                    `json:"insertionOrder,omitempty"`
+	Items                *Property                `json:"items,omitempty"`
+	Maximum              *json.Number             `json:"maximum,omitempty"`
+	MaxItems             *int                     `json:"maxItems,omitempty"`
+	MaxLength            *int                     `json:"maxLength,omitempty"`
+	Minimum              *json.Number             `json:"minimum,omitempty"`
+	MinItems             *int                     `json:"minItems,omitempty"`
+	MinLength            *int                     `json:"minLength,omitempty"`
+	OneOf                []*PropertySubschema     `json:"oneOf,omitempty"`
+	Pattern              *string                  `json:"pattern,omitempty"`
+	PatternProperties    map[string]*Property     `json:"patternProperties,omitempty"`
+	Properties           map[string]*Property     `json:"properties,omitempty"`
+	Ref                  *Reference               `json:"$ref,omitempty"`
+	RelationshipRef      *PropertyRelationshipRef `json:"relationshipRef,omitempty"`
+	Required             []string                 `json:"required,omitempty"`
+	Type                 *Type                    `json:"type,omitempty"`
+	UniqueItems          *bool                    `json:"uniqueItems,omitempty"`
 }
 
 // String returns a string representation of Property.

--- a/property_relationship_ref.go
+++ b/property_relationship_ref.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cfschema
+
+type PropertyRelationshipRef struct {
+	PropertyPath *PropertyJsonPointer `json:"propertyPath,omitempty"`
+	TypeName     *string              `json:"typeName,omitempty"`
+}

--- a/property_relationship_ref_test.go
+++ b/property_relationship_ref_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cfschema_test
+
+import (
+	"testing"
+
+	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
+)
+
+func TestPropertyRelationshipRef(t *testing.T) {
+	testCases := []struct {
+		TestDescription      string
+		MetaSchemaPath       string
+		ResourceSchemaPath   string
+		PropertyPath         []string
+		ExpectedPropertyPath string
+		ExpectedTypeName     string
+	}{
+		{
+			TestDescription:      "relationshipRef",
+			MetaSchemaPath:       "provider.definition.schema.v1.json",
+			ResourceSchemaPath:   "AWS_S3_MultiRegionAccessPoint.json",
+			PropertyPath:         []string{"Regions", "Bucket"},
+			ExpectedPropertyPath: "/properties/BucketName",
+			ExpectedTypeName:     "AWS::S3::Bucket",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.TestDescription, func(t *testing.T) {
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
+
+			err := resource.Expand()
+
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			properties := resource.Properties
+			for i, propertyName := range testCase.PropertyPath {
+				property, ok := properties[propertyName]
+
+				if !ok {
+					t.Fatalf("expected resource property (%s), got none", propertyName)
+				}
+
+				if i == len(testCase.PropertyPath)-1 {
+					if actual, expected := *property.RelationshipRef.TypeName, testCase.ExpectedTypeName; actual != expected {
+						t.Errorf("expected resource property (%s) RelationshipRef.TypeName, (%s), got: %s", propertyName, expected, actual)
+					}
+					if actual, expected := *property.RelationshipRef.PropertyPath, testCase.ExpectedPropertyPath; actual.String() != expected {
+						t.Errorf("expected resource property (%s) RelationshipRef.PropertyPath, (%s), got: %s", propertyName, expected, actual)
+					}
+				} else {
+					switch typ := (*property.Type).String(); typ {
+					case cfschema.PropertyTypeArray:
+						properties = property.Items.Properties
+					case cfschema.PropertyTypeObject:
+						properties = property.Properties
+					default:
+						t.Fatalf("resource property (%s) type (%s)", propertyName, typ)
+					}
+				}
+			}
+		})
+	}
+}

--- a/property_subschema_test.go
+++ b/property_subschema_test.go
@@ -4,7 +4,6 @@
 package cfschema_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
@@ -43,29 +42,7 @@ func TestPropertySubschema_Resource(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
 			if actual, expected := len(resource.AllOf), testCase.ExpectedAllOf; actual != expected {
 				t.Errorf("expected %d allOf elements, got: %d", expected, actual)
@@ -111,31 +88,9 @@ func TestPropertySubschema_Property(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
-
-			err = resource.Expand()
+			err := resource.Expand()
 
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("unexpected error: %s", err)

--- a/property_test.go
+++ b/property_test.go
@@ -50,29 +50,6 @@ func TestProperty_IsRequired(t *testing.T) {
 	}
 }
 
-func TestProperty_RelationshipRef(t *testing.T) {
-	testCases := []struct {
-		TestDescription    string
-		MetaSchemaPath     string
-		ResourceSchemaPath string
-		ExpectError        bool
-	}{
-		{
-			TestDescription:    "relationshipRef",
-			MetaSchemaPath:     "provider.definition.schema.v1.json",
-			ResourceSchemaPath: "AWS_S3_MultiRegionAccessPoint.json",
-		},
-	}
-
-	for _, testCase := range testCases {
-		testCase := testCase
-
-		t.Run(testCase.TestDescription, func(t *testing.T) {
-			loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
-		})
-	}
-}
-
 func loadAndValidateResourceSchema(t *testing.T, metaSchemaPath, resourceSchemaPath string) *cfschema.Resource {
 	metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", metaSchemaPath))
 

--- a/property_test.go
+++ b/property_test.go
@@ -64,8 +64,6 @@ func TestProperty_RelationshipRef(t *testing.T) {
 		},
 	}
 
-	t.Skip("relationshipRef is not yet implemented")
-
 	for _, testCase := range testCases {
 		testCase := testCase
 

--- a/property_test.go
+++ b/property_test.go
@@ -4,12 +4,13 @@
 package cfschema_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
 )
 
-func TestPropertyIsRequired(t *testing.T) {
+func TestProperty_IsRequired(t *testing.T) {
 	testCases := []struct {
 		TestDescription string
 		Property        *cfschema.Property
@@ -47,4 +48,57 @@ func TestPropertyIsRequired(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProperty_RelationshipRef(t *testing.T) {
+	testCases := []struct {
+		TestDescription    string
+		MetaSchemaPath     string
+		ResourceSchemaPath string
+		ExpectError        bool
+	}{
+		{
+			TestDescription:    "relationshipRef",
+			MetaSchemaPath:     "provider.definition.schema.v1.json",
+			ResourceSchemaPath: "AWS_S3_MultiRegionAccessPoint.json",
+		},
+	}
+
+	t.Skip("relationshipRef is not yet implemented")
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		t.Run(testCase.TestDescription, func(t *testing.T) {
+			loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
+		})
+	}
+}
+
+func loadAndValidateResourceSchema(t *testing.T, metaSchemaPath, resourceSchemaPath string) *cfschema.Resource {
+	metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", metaSchemaPath))
+
+	if err != nil {
+		t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
+	}
+
+	resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", resourceSchemaPath))
+
+	if err != nil {
+		t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
+	}
+
+	err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
+
+	if err != nil {
+		t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
+	}
+
+	resource, err := resourceSchema.Resource()
+
+	if err != nil {
+		t.Fatalf("unexpected Resource() error: %s", err)
+	}
+
+	return resource
 }

--- a/resource_expand_test.go
+++ b/resource_expand_test.go
@@ -4,7 +4,6 @@
 package cfschema_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	cfschema "github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go"
@@ -35,31 +34,9 @@ func TestResourceExpand(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
-
-			err = resource.Expand()
+			err := resource.Expand()
 
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("unexpected error: %s", err)
@@ -126,31 +103,9 @@ func TestResourceExpand_NestedDefinition(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
-
-			err = resource.Expand()
+			err := resource.Expand()
 
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("unexpected error: %s", err)
@@ -218,31 +173,9 @@ func TestResourceExpand_PatternProperties(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
-
-			err = resource.Expand()
+			err := resource.Expand()
 
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("unexpected error: %s", err)
@@ -362,31 +295,9 @@ func TestResourceExpand_SecondLevelNestedDefinition(t *testing.T) {
 		testCase := testCase
 
 		t.Run(testCase.TestDescription, func(t *testing.T) {
-			metaSchema, err := cfschema.NewMetaJsonSchemaPath(filepath.Join("testdata", testCase.MetaSchemaPath))
+			resource := loadAndValidateResourceSchema(t, testCase.MetaSchemaPath, testCase.ResourceSchemaPath)
 
-			if err != nil {
-				t.Fatalf("unexpected NewMetaJsonSchemaPath() error: %s", err)
-			}
-
-			resourceSchema, err := cfschema.NewResourceJsonSchemaPath(filepath.Join("testdata", testCase.ResourceSchemaPath))
-
-			if err != nil {
-				t.Fatalf("unexpected NewResourceJsonSchemaPath() error: %s", err)
-			}
-
-			err = metaSchema.ValidateResourceJsonSchema(resourceSchema)
-
-			if err != nil {
-				t.Fatalf("unexpected ValidateResourceJsonSchema() error: %s", err)
-			}
-
-			resource, err := resourceSchema.Resource()
-
-			if err != nil {
-				t.Fatalf("unexpected Resource() error: %s", err)
-			}
-
-			err = resource.Expand()
+			err := resource.Expand()
 
 			if err != nil && !testCase.ExpectError {
 				t.Fatalf("unexpected error: %s", err)

--- a/testdata/AWS_S3_MultiRegionAccessPoint.json
+++ b/testdata/AWS_S3_MultiRegionAccessPoint.json
@@ -1,0 +1,126 @@
+{
+    "typeName": "AWS::S3::MultiRegionAccessPoint",
+    "description": "AWS::S3::MultiRegionAccessPoint is an Amazon S3 resource type that dynamically routes S3 requests to easily satisfy geographic compliance requirements based on customer-defined routing policies.",
+    "definitions": {
+        "PublicAccessBlockConfiguration": {
+            "type": "object",
+            "properties": {
+                "BlockPublicAcls": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should block public access control lists (ACLs) for buckets in this account. Setting this element to TRUE causes the following behavior:\n- PUT Bucket acl and PUT Object acl calls fail if the specified ACL is public.\n - PUT Object calls fail if the request includes a public ACL.\n. - PUT Bucket calls fail if the request includes a public ACL.\nEnabling this setting doesn't affect existing policies or ACLs."
+                },
+                "IgnorePublicAcls": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should ignore public ACLs for buckets in this account. Setting this element to TRUE causes Amazon S3 to ignore all public ACLs on buckets in this account and any objects that they contain. Enabling this setting doesn't affect the persistence of any existing ACLs and doesn't prevent new public ACLs from being set."
+                },
+                "BlockPublicPolicy": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should block public bucket policies for buckets in this account. Setting this element to TRUE causes Amazon S3 to reject calls to PUT Bucket policy if the specified bucket policy allows public access. Enabling this setting doesn't affect existing bucket policies."
+                },
+                "RestrictPublicBuckets": {
+                    "type": "boolean",
+                    "description": "Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this element to TRUE restricts access to this bucket to only AWS services and authorized users within this account if the bucket has a public policy.\nEnabling this setting doesn't affect previously stored bucket policies, except that public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked."
+                }
+            },
+            "additionalProperties": false
+        },
+        "Region": {
+            "type": "object",
+            "properties": {
+                "Bucket": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9][a-z0-9//.//-]*[a-z0-9]$",
+                    "relationshipRef": {
+                        "typeName": "AWS::S3::Bucket",
+                        "propertyPath": "/properties/BucketName"
+                    }
+                }, 
+                "BucketAccountId": {
+                    "type": "string",
+                    "minLength": 12,
+                    "maxLength": 12,
+                    "pattern": "^[0-9]{12}$"
+                }
+            },
+            "required": [
+                "Bucket"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "Name": {
+            "description": "The name you want to assign to this Multi Region Access Point.",
+            "type": "string",
+            "pattern": "^[a-z0-9][-a-z0-9]{1,48}[a-z0-9]$",
+            "minLength": 3,
+            "maxLength": 50
+        },
+        "Alias": {
+            "description": "The alias is a unique identifier to, and is part of the public DNS name for this Multi Region Access Point",
+            "type": "string"
+        },
+        "CreatedAt": {
+            "description": "The timestamp of the when the Multi Region Access Point is created",
+            "type": "string"
+        },
+        "PublicAccessBlockConfiguration": {
+            "description": "The PublicAccessBlock configuration that you want to apply to this Multi Region Access Point. You can enable the configuration options in any combination. For more information about when Amazon S3 considers a bucket or object public, see https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html#access-control-block-public-access-policy-status 'The Meaning of Public' in the Amazon Simple Storage Service Developer Guide.",
+            "$ref": "#/definitions/PublicAccessBlockConfiguration"
+        },
+        "Regions": {
+            "description": "The list of buckets that you want to associate this Multi Region Access Point with.",
+            "type": "array",
+            "uniqueItems": true,
+            "minItems": 1,
+            "items": {
+                "description": "The name of the bucket that represents of the region belonging to this Multi Region Access Point.",
+                "$ref": "#/definitions/Region"
+            }
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "Regions"
+    ],
+    "readOnlyProperties": [
+        "/properties/Alias",
+        "/properties/CreatedAt"
+    ],
+    "createOnlyProperties": [
+        "/properties/Name",
+        "/properties/PublicAccessBlockConfiguration",
+        "/properties/Regions"
+    ],
+    "primaryIdentifier": [
+        "/properties/Name"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "s3:CreateMultiRegionAccessPoint",
+                "s3:DescribeMultiRegionAccessPointOperation",
+                "s3:GetMultiRegionAccessPoint"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "s3:GetMultiRegionAccessPoint"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "s3:DeleteMultiRegionAccessPoint",
+                "s3:DescribeMultiRegionAccessPointOperation",
+                "s3:GetMultiRegionAccessPoint"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "s3:ListMultiRegionAccessPoints"
+            ]
+        }
+    }
+}

--- a/testdata/base.definition.schema.v1.json
+++ b/testdata/base.definition.schema.v1.json
@@ -185,6 +185,24 @@
                         },
                         "oneOf": {
                             "$ref": "#/definitions/schemaArray"
+                        },
+                        "relationshipRef": {
+                            "description": "Temporary local definition",
+                            "type": "object",
+                            "properties": {
+                                "typeName": {
+                                    "$ref": "#/properties/typeName"
+                                },
+                                "propertyPath": {
+                                    "type": "string",
+                                    "format": "json-pointer"
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "typeName",
+                                "propertyPath"
+                            ]
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
Adds a temporary local definition of the `relationshipRef` definition, based on a real-life example.

Closes https://github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go/issues/53.
Relates https://github.com/aws-cloudformation/cloudformation-resource-schema/issues/151.