### PR TITLE
Require Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,11 @@ jobs:
     name: go test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-      with:
-        go-version: 1.16
-    - run: go test ./...
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version-file: go.mod
+      - name: Go Test
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,9 @@ module github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go
 
 go 1.21
 
-require (
-	github.com/hashicorp/go-multierror v1.1.1
-	github.com/xeipuuv/gojsonschema v1.2.0
-)
+require github.com/xeipuuv/gojsonschema v1.2.0
 
 require (
-	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go
 
-go 1.18
+go 1.21
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/json_schema.go
+++ b/json_schema.go
@@ -4,11 +4,11 @@
 package cfschema
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -44,17 +44,17 @@ func (s *jsonSchema) validate(loader gojsonschema.JSONLoader) error {
 	result, err := s.schema.Validate(loader)
 
 	if err != nil {
-		return fmt.Errorf("Unable to Validate JSON Schema: %w", err)
+		return fmt.Errorf("validating JSON Schema: %w", err)
 	}
 
 	if !result.Valid() {
-		var errs *multierror.Error
+		var errs []error
 
 		for _, resultError := range result.Errors() {
-			errs = multierror.Append(errs, fmt.Errorf("%s", resultError.String()))
+			errs = append(errs, errors.New(resultError.String()))
 		}
 
-		return fmt.Errorf("Validation Errors: %w", errs)
+		return fmt.Errorf("validation errors: %w", errors.Join(errs...))
 	}
 
 	return nil


### PR DESCRIPTION
Closes https://github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go/issues/55.

```console
% go1.21.8 test .
ok  	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go	0.836s
```