### PR TITLE
Add `arrayType`definition for testing

### DIFF
--- a/testdata/base.definition.schema.v1.json
+++ b/testdata/base.definition.schema.v1.json
@@ -61,6 +61,15 @@
                             "type": "boolean",
                             "default": true
                         },
+                        "arrayType": {
+                            "description": "When set to AttributeList, it indicates that the array is of nested type objects, and when set to Standard it indicates that the array consists of primitive types",
+                            "type": "string",
+                            "default": "Standard",
+                            "enum": [
+                                "Standard",
+                                "AttributeList"
+                            ]
+                        },
                         "$ref": {
                             "$ref": "http://json-schema.org/draft-07/schema#/properties/$ref"
                         },


### PR DESCRIPTION
Relates https://github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go/pull/48.
Relates https://github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go/issues/45.